### PR TITLE
Use specific command for pnpm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## Requirements
 
-- **[PNPM] [7](https://pnpm.io/installation)**
+- **[PNPM] [7](https://pnpm.io/installation)**,
+  Install using:
+
+```
+npm install -g pnpm
+```
+
 - **Node >=14**
 
 [pnpm]: https://pnpm.io/


### PR DESCRIPTION
When installing `pnpm` from the the first option on the pnpm website, it installed `v8` which was not compatible with the app. Using the global `npm` results in the version we want so I specify that install command in the README 